### PR TITLE
Fixing a few static links, in response to issue #152 

### DIFF
--- a/app/about-window/components/AboutWindowFooter.tsx
+++ b/app/about-window/components/AboutWindowFooter.tsx
@@ -45,7 +45,7 @@ export default class AboutWindowFooter extends React.PureComponent<Props, {}> {
         >
           About Station
         </a>
-        <a className={classes!.link} href="https://intercom.help/station" target="_blank">
+        <a className={classes!.link} href="https://getstation.com/" target="_blank">
           Support
         </a>
       </footer>

--- a/app/app-worker.ts
+++ b/app/app-worker.ts
@@ -257,7 +257,7 @@ export class BrowserXAppWorker {
         this.dispatch(toggleKbdShortcuts());
         break;
       case 'show-community':
-        this.dispatch(dispatchUrl('https://feedback.getstation.com/'));
+        this.dispatch(dispatchUrl('https://github.com/getstation/desktop-app/issues'));
         break;
       case 'show-release-notes':
         this.dispatch(setReleaseNotesSubdockVisibility(true));

--- a/app/app-worker.ts
+++ b/app/app-worker.ts
@@ -262,7 +262,8 @@ export class BrowserXAppWorker {
       case 'show-release-notes':
         this.dispatch(setReleaseNotesSubdockVisibility(true));
         break;
-      case 'station-tour':
+      case 'station-features':
+        this.dispatch(dispatchUrl('https://getstation.com/features'));
         break;
       case 'reset-current-application':
         this.dispatch(updateUI('confirmResetApplicationModal', 'isVisible', getFocus(this.getState())));

--- a/app/auto-update/sagas.ts
+++ b/app/auto-update/sagas.ts
@@ -80,7 +80,7 @@ function* checkForUpdates() {
 }
 
 function* doOpenReleaseNotes() {
-  yield call(dispatchUrlSaga, { url: 'https://feedback.getstation.com/changelog' });
+  yield call(dispatchUrlSaga, { url: 'https://github.com/getstation/desktop-app/releases/' });
 }
 
 function* consumeUpdateLockFile() {

--- a/app/dialogs/components/DialogItem.tsx
+++ b/app/dialogs/components/DialogItem.tsx
@@ -38,7 +38,7 @@ export interface StateProps {
 
 export type Props = OwnProps & StateProps;
 
-const annoyedLink = 'https://intercom.help/station/app-specific-questions/i-find-google-calendar-reminder-popups-annoying';
+const annoyedLink = 'https://github.com/getstation/desktop-app/wiki/FAQ-%7C-%F0%9F%93%A3-Notifications-&-badges#i-find-google-calendar-reminder-popups-annoying';
 
 const actionCTAOnBottom = (props: Props) =>
   props.dialog.get('actions').some((action) => Boolean(action!.get('text')));

--- a/app/onboarding/Onboarding.tsx
+++ b/app/onboarding/Onboarding.tsx
@@ -198,7 +198,7 @@ class OnboardingImpl extends React.PureComponent<Props, State> {
         emails={emails}
         onEmailsChange={this.updateEmails}
         loginButtonDisabled={loginButtonDisabled}
-        privacyPoliciesLink={'https://intercom.help/station/data-and-privacy/station-privacy-policies'}
+        privacyPoliciesLink={'https://github.com/getstation/desktop-app/wiki/FAQ#-data--privacy'}
         isWindowFocused={isWindowFocused}
         onCloseWindow={this.handleCloseWindow}
         onMinimizeWindow={this.handleMinimizeWindow}

--- a/app/services/services/authentication/main.ts
+++ b/app/services/services/authentication/main.ts
@@ -79,7 +79,7 @@ export class AuthenticationServiceImpl extends AuthenticationService implements 
     this.server = new LoopbackRedirectServer({
       port: LOOPBACK_INTERFACE_REDIRECTION_PORT,
       callbackPath: '/callback',
-      successRedirectURL: 'https://getstation.com/app-login-success/',
+      successRedirectURL: 'https://getstation.com/',
     });
 
     shell.openExternal(urlToLoad);

--- a/app/services/services/menu/menuManager.ts
+++ b/app/services/services/menu/menuManager.ts
@@ -239,7 +239,7 @@ export class BrowserXMenuManager extends EventEmitter {
         {
           label: 'Discover Station\'s features',
           click(_menuItem: Electron.MenuItem, _browserWindow: Electron.BrowserWindow, event: Electron.KeyboardEvent) {
-            emit('click-item', { event: serializedKeyboardEvent(event), action: 'station-tour' });
+            emit('click-item', { event: serializedKeyboardEvent(event), action: 'station-features' });
           },
         },
         {
@@ -290,7 +290,7 @@ export class BrowserXMenuManager extends EventEmitter {
         {
           label: 'Discover Station\'s features',
           click(_menuItem: Electron.MenuItem, _browserWindow: Electron.BrowserWindow, event: Electron.KeyboardEvent) {
-            emit('click-item', { event: serializedKeyboardEvent(event), action: 'station-tour' });
+            emit('click-item', { event: serializedKeyboardEvent(event), action: 'station-features' });
           },
         },
         {

--- a/app/services/services/menu/menuManager.ts
+++ b/app/services/services/menu/menuManager.ts
@@ -6,11 +6,11 @@ import { isDarwin } from '../../../utils/process';
 import { serializedKeyboardEvent } from './helpers';
 
 const openFaq = () => {
-  shell.openExternal('https://intercom.help/station');
+  shell.openExternal('https://github.com/getstation/desktop-app/wiki/FAQ');
 };
 
 const openPrivacyPolicies = () => {
-  shell.openExternal('https://intercom.help/station/data-and-privacy/station-privacy-policies');
+  shell.openExternal('https://github.com/getstation/desktop-app/wiki/FAQ#-data--privacy');
 };
 
 export class BrowserXMenuManager extends EventEmitter {

--- a/appstore/src/components/AppStoreContent/AppStoreRequest/AppRequestSteps/AppRequestError/AppRequestError.tsx
+++ b/appstore/src/components/AppStoreContent/AppStoreRequest/AppRequestSteps/AppRequestError/AppRequestError.tsx
@@ -35,7 +35,7 @@ const AppRequestError = () => {
       <img className={classes.errorImage} src={astroAwkwardPath} />
       <h4 className={classes.title}>Something went wrong, <br /> we're sorry.</h4>
       <div className={classes.text}>
-        Please retry in couples of minutes or post topic in our <a target="_blank" href="https://feedback.getstation.com/">Community</a> forum: we'll be there for you.
+        Please retry in couples of minutes or post topic in our <a target="_blank" href="https://github.com/getstation/desktop-app/issues">Community</a> forum: we'll be there for you.
       </div>
     </div>
   );

--- a/stories/screens/onboarding.tsx
+++ b/stories/screens/onboarding.tsx
@@ -29,7 +29,7 @@ storiesOf('Screens|Onboarding', module)
       onExpandWindow={action('onExpandWindow')}
       isDarwin={boolean('is Darwin', true)}
       validateEmail={validateEmail}
-      privacyPoliciesLink={'https://intercom.help/station/data-and-privacy/station-privacy-policies'}
+      privacyPoliciesLink={'https://github.com/getstation/desktop-app/wiki/FAQ#-data--privacy'}
       searchInputValue={text('searchInputValue', '')}
       handleSearchInputValue={action('handleSearchInputValue')}
     />


### PR DESCRIPTION
### What is this PR
Fixing a few static links, in response to issue #152 

- Changed links, mostly from intercom to GitHub.
- Remove Station tour in help menu (didn't find it), instead it opens the features' page on station website.

### How does it work
No breaking changes

### Test instructions
None

### Important Note : 
**It doesn't fix the https://getstation.com/app-login-success/ link**