### PR TITLE
Remove unactive README notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-⚠️ This project is not actively maintained. Forks or PRs encouraged (PRs will be reviewed)
-
 # Station Desktop Application
 
 ## Table of Contents


### PR DESCRIPTION
It appears that this project is now actively maintained, at least since April.

In March, I tried adding Station to [awesome-mac](https://github.com/jaywcjlove/awesome-mac/pull/1206), a Mac application list with over 60k stars, but the repo owner saw the `⚠️ This project is not actively maintained` notice. Might as well remove it, and I'll send another PR over so that more users can find this browser.