### PR TITLE
Fix symlinking to `station-desktop-app` script

### DIFF
--- a/scripts/after-pack.js
+++ b/scripts/after-pack.js
@@ -17,7 +17,7 @@ exports.default = async function(context) {
 
   const wrapperScript = 
     `#!/bin/sh 
-    nohup $(dirname $0)/station-desktop-app.bin --no-sandbox "$@" >/dev/null 2>&1 &
+    nohup "$(dirname "$(readlink -f "$0")")/station-desktop-app.bin" --no-sandbox "$@" >/dev/null 2>&1 &
     `;
   fs.writeFileSync('station-desktop-app', wrapperScript);
   fs.chmodSync('station-desktop-app', '755');


### PR DESCRIPTION
When symlinking to shell script `dirname $0` returns the path to symlink instead of the path to the script, symlink dereferencing is required for this script to work as a symlink.

### What is this PR
Fix symlink path dereferencing in the shell script `station-desktop-app`

### How does it work
Run `readlink -f` before `dirname` to dereference potential symlink (doesn't interfere with the normal operation when not symlinked)

### Test instructions
1. symlink `station-desktop-app` in a different path
2. call the symlink
3. it doesn't work without the path but works fine with it.
