### PR TITLE
Enabling `allow-insecure-localhost` #212

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -167,6 +167,9 @@ const lazyBxAppMain = () => {
 };
 
 const init = () => {
+
+  app.commandLine.appendSwitch('allow-insecure-localhost');
+
   overrideUserDataPath();
   applyLogLevel();
 


### PR DESCRIPTION
### What is this PR

Fixes **Enabling the enablment of allow-insecure-localhost for Local Apps enhancement** #212 

### Test instructions

add custom app which works on https://localhost... with wrong SSL. It should work without errors now.