### PR TITLE
Remove hardcoded architecture for npm/yarn

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,3 @@
 runtime = electron
 disturl = https://electronjs.org/headers
 target = 25.8.2
-arch = x64
-#arch = arm64


### PR DESCRIPTION
### What is this PR
Fix for apple silicon development

### How does it work
Removing the hardcoded architecture declared in `.npmrc` this should not be needed since its auto detected by electron

### Test instructions
1. Clean clone of repo
2. `yarn install`
3. `yarn run dev`
