### PR TITLE
Fix outdated Proton Mail URL

### DIFF
--- a/appstore/src/applications/mockedMostPopularApps.ts
+++ b/appstore/src/applications/mockedMostPopularApps.ts
@@ -1281,7 +1281,7 @@ const TMP_MOST_POP_APPS = {
       },
       themeColor: '#1E213F',
       iconURL: 'https://cdn.filestackcontent.com/kMqInOmTOuMJwO1VqlBA',
-      startURL: 'https://mail.protonmail.com',
+      startURL: 'https://mail.proton.me',
       isChromeExtension: false,
       bxAppManifestURL:
         'http://localhost:4001/application-recipe/550/bxAppManifest.json',
@@ -2215,7 +2215,7 @@ const TMP_MOST_POP_APPS = {
       },
       themeColor: '#1E213F',
       iconURL: 'https://cdn.filestackcontent.com/kMqInOmTOuMJwO1VqlBA',
-      startURL: 'https://mail.protonmail.com',
+      startURL: 'https://mail.proton.me',
       isChromeExtension: false,
       bxAppManifestURL:
         'http://localhost:4001/application-recipe/550/bxAppManifest.json',

--- a/manifests/definitions/550.json
+++ b/manifests/definitions/550.json
@@ -1,7 +1,7 @@
 {
   "name": "Proton Mail",
   "category": "Communication & Collaboration",
-  "start_url": "https://mail.protonmail.com",
+  "start_url": "https://mail.proton.me",
   "icons": [
     {
       "src": "https://cdn.filestackcontent.com/ekRf8BPoRdemQsR2UZMA"
@@ -12,11 +12,7 @@
     }
   ],
   "theme_color": "#1E213F",
-  "scope": "https://mail.protonmail.com",
+  "scope": "https://mail.proton.me",
   "bx_keep_always_loaded": true,
-  "bx_legacy_service_id": "protonmail",
-  "extended_scopes": [
-    "https://mail.protonmail.com",
-    "https://protonmail.com"
-  ]
+  "bx_legacy_service_id": "protonmail"
 }


### PR DESCRIPTION
Fixed outdated Proton Mail URL **proton.me** instead of **protonmail.com**