### PR TITLE
Blocked pop-ups fix (Part 3) 

### DIFF
--- a/app/services/services/tab-webcontents/main.ts
+++ b/app/services/services/tab-webcontents/main.ts
@@ -217,7 +217,8 @@ export class TabWebContentsServiceImpl extends TabWebContentsService implements 
    */
   isNewWindowForUserRequest(details: HandlerDetails): boolean {
 
-    if (details.url.startsWith('about:blank')) {
+    if (details.url.startsWith('about:blank')
+        || details.url.startsWith('https://accounts.google.com/o/oauth2/')) {
       return true;
     }
 


### PR DESCRIPTION
Fixed #295

The only way to determine the auth window for `Customer.io` is to check the request URL.
From the other side I don't think that Google will change this URL :)
