### PR TITLE
Multi-account support

### DIFF
--- a/app/app-main.js
+++ b/app/app-main.js
@@ -22,8 +22,10 @@ export default class BrowserXAppMain extends EventEmitter {
       if (typeof this.onOpen === 'function') {
         await this.onOpen();
       }
-
     });
+    app.on('session-created', (session) => {
+      enhanceSession(session);
+    })
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/app/applications/Application.tsx
+++ b/app/applications/Application.tsx
@@ -102,6 +102,7 @@ export interface OwnProps {
   applicationIcon: Maybe<string>,
   themeColor: Maybe<string>,
   notUseNativeWindowOpen: Maybe<boolean>,
+  isolatedSession: Maybe<boolean>,
 
   appFocus: Maybe<number>,
   isOnline: Maybe<boolean>,
@@ -407,6 +408,7 @@ class ApplicationImpl extends React.PureComponent {
       crashed, errorCode, errorDescription,
       canGoBack, themeGradient, email,
       promptBasicAuth, performBasicAuth, basicAuthInfo,
+      isolatedSession,
     } = this.props;
 
     return (
@@ -454,6 +456,7 @@ class ApplicationImpl extends React.PureComponent {
           allowpopups={true}
           loading={this.props.loading}
           webviewRef={this.setWebviewRef}
+          partition={isolatedSession ? `persist:${applicationId}` : ''}
           onPageTitleUpdated={this.handleTitleUpdated}
           onPageFaviconUpdated={this.handleFaviconUpdated}
           onDidStartLoading={this.handleDidStartLoading}
@@ -489,6 +492,7 @@ const Application = compose(
         applicationIcon: manifestData.interpretedIconURL(),
         themeColor: manifestData.theme_color(),
         notUseNativeWindowOpen: manifestData.bx_not_use_native_window_open_on_host(),
+        isolatedSession: manifestData.bx_isolated_session(),
 
         isOnline: stationStatus.isOnline(),
         appFocus: stationStatus.focus(),

--- a/app/applications/Application.tsx
+++ b/app/applications/Application.tsx
@@ -102,7 +102,7 @@ export interface OwnProps {
   applicationIcon: Maybe<string>,
   themeColor: Maybe<string>,
   notUseNativeWindowOpen: Maybe<boolean>,
-  isolatedSession: Maybe<boolean>,
+  useDefaultSession: Maybe<boolean>,
 
   appFocus: Maybe<number>,
   isOnline: Maybe<boolean>,
@@ -408,7 +408,7 @@ class ApplicationImpl extends React.PureComponent {
       crashed, errorCode, errorDescription,
       canGoBack, themeGradient, email,
       promptBasicAuth, performBasicAuth, basicAuthInfo,
-      isolatedSession,
+      useDefaultSession,
     } = this.props;
 
     return (
@@ -456,7 +456,7 @@ class ApplicationImpl extends React.PureComponent {
           allowpopups={true}
           loading={this.props.loading}
           webviewRef={this.setWebviewRef}
-          partition={isolatedSession ? `persist:${applicationId}` : ''}
+          partition={useDefaultSession ? '' : `persist:${applicationId}`}
           onPageTitleUpdated={this.handleTitleUpdated}
           onPageFaviconUpdated={this.handleFaviconUpdated}
           onDidStartLoading={this.handleDidStartLoading}
@@ -492,7 +492,7 @@ const Application = compose(
         applicationIcon: manifestData.interpretedIconURL(),
         themeColor: manifestData.theme_color(),
         notUseNativeWindowOpen: manifestData.bx_not_use_native_window_open_on_host(),
-        isolatedSession: manifestData.bx_isolated_session(),
+        useDefaultSession: manifestData.bx_use_default_session(),
 
         isOnline: stationStatus.isOnline(),
         appFocus: stationStatus.focus(),

--- a/app/applications/manifest-provider/bxAppManifest.d.ts
+++ b/app/applications/manifest-provider/bxAppManifest.d.ts
@@ -19,7 +19,7 @@ export interface BxAppManifest {
   bx_keep_always_loaded?: boolean;
   bx_not_use_native_window_open_on_host?: boolean;
   bx_no_dock?: boolean;
-  bx_isolated_session?: boolean;
+  bx_use_default_session?: boolean;
   bx_single_page?: boolean;
   bx_multi_instance_config?: MultiInstanceConfig;
   bx_legacy_service_id?: string;

--- a/app/applications/manifest-provider/bxAppManifest.d.ts
+++ b/app/applications/manifest-provider/bxAppManifest.d.ts
@@ -19,6 +19,7 @@ export interface BxAppManifest {
   bx_keep_always_loaded?: boolean;
   bx_not_use_native_window_open_on_host?: boolean;
   bx_no_dock?: boolean;
+  bx_isolated_session?: boolean;
   bx_single_page?: boolean;
   bx_multi_instance_config?: MultiInstanceConfig;
   bx_legacy_service_id?: string;

--- a/app/applications/queries@local.gql
+++ b/app/applications/queries@local.gql
@@ -14,6 +14,7 @@ query GetApplicationState($applicationId: String!, $tabId: String) @live @local 
         instance_wording,
       },
       bx_not_use_native_window_open_on_host,
+      bx_isolated_session,
       bx_legacy_service_id,
     },
     isSnoozed,

--- a/app/applications/queries@local.gql
+++ b/app/applications/queries@local.gql
@@ -14,7 +14,7 @@ query GetApplicationState($applicationId: String!, $tabId: String) @live @local 
         instance_wording,
       },
       bx_not_use_native_window_open_on_host,
-      bx_isolated_session,
+      bx_use_default_session,
       bx_legacy_service_id,
     },
     isSnoozed,

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -282,8 +282,8 @@ type ManifestData {
  bx_legacy_service_id: String,
  """Native window on host"""
  bx_not_use_native_window_open_on_host: Boolean,
- """Use isolated session for each app instance"""
- bx_isolated_session: Boolean,
+ """true - use default shared session. false or unset - isolated session for each app instance"""
+ bx_use_default_session: Boolean,
  """Application Chrome Extension ID"""
  cxExtensionId: ID,
 }

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -282,6 +282,8 @@ type ManifestData {
  bx_legacy_service_id: String,
  """Native window on host"""
  bx_not_use_native_window_open_on_host: Boolean,
+ """Use isolated session for each app instance"""
+ bx_isolated_session: Boolean,
  """Application Chrome Extension ID"""
  cxExtensionId: ID,
 }

--- a/app/main.ts
+++ b/app/main.ts
@@ -1,6 +1,6 @@
 /* tslint:disable global-require, no-import-side-effect */
 import './dotenv';
-import { app, session, BrowserWindow, ipcMain, dialog } from 'electron';
+import { app, BrowserWindow, ipcMain, dialog } from 'electron';
 import log, { LevelOption } from 'electron-log';
 // @ts-ignore: no declaration file
 import { format } from 'electron-log/lib/format';
@@ -11,7 +11,6 @@ import { BrowserWindowManagerServiceImpl } from './services/services/browser-win
 import services from './services/servicesManager';
 import { getUrlToLoad } from './utils/dev';
 import { isPackaged } from './utils/env';
-import { enhanceSession } from './session';
 import * as remoteMain from '@electron/remote/main';
 
 bootServices(); // all side effects related to services (in main process)

--- a/manifests/definitions/1.json
+++ b/manifests/definitions/1.json
@@ -7,5 +7,6 @@
   "scope": "station://appstore",
   "bx_no_dock": true,
   "doNotList": true,
+  "bx_use_default_session": true,
   "bx_legacy_service_id": "appstore"
 }

--- a/manifests/definitions/100.json
+++ b/manifests/definitions/100.json
@@ -27,5 +27,6 @@
     "subdomain_ui_help": "Enter your account's  domain.",
     "subdomain_ui_suffix": ".atlassian.net"
   },
+  "bx_use_default_session": true,
   "recommendedPosition": "23"
 }

--- a/manifests/definitions/101.json
+++ b/manifests/definitions/101.json
@@ -22,5 +22,6 @@
     "subdomain_title": "Desk domain",
     "subdomain_ui_help": "Enter your Desk account's domain.",
     "subdomain_ui_suffix": ".desk.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/119.json
+++ b/manifests/definitions/119.json
@@ -23,5 +23,6 @@
     "subdomain_title": "AWS domain",
     "subdomain_ui_help": "Enter your account's  domain.",
     "subdomain_ui_suffix": ".signin.aws.amazon.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/122.json
+++ b/manifests/definitions/122.json
@@ -12,5 +12,6 @@
   "scope": "https://web.whatsapp.com",
   "bx_keep_always_loaded": true,
   "bx_legacy_service_id": "whatsapp",
+  "bx_isolated_session": true,
   "recommendedPosition": "4"
 }

--- a/manifests/definitions/122.json
+++ b/manifests/definitions/122.json
@@ -12,6 +12,5 @@
   "scope": "https://web.whatsapp.com",
   "bx_keep_always_loaded": true,
   "bx_legacy_service_id": "whatsapp",
-  "bx_isolated_session": true,
   "recommendedPosition": "4"
 }

--- a/manifests/definitions/123.json
+++ b/manifests/definitions/123.json
@@ -15,5 +15,6 @@
     "presets": [
       "on-premise"
     ]
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/124.json
+++ b/manifests/definitions/124.json
@@ -26,5 +26,6 @@
     "subdomain_title": "Gitlab domain",
     "subdomain_ui_help": "Enter your team's Gitlab domain.",
     "subdomain_ui_suffix": ".gitlab.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/125.json
+++ b/manifests/definitions/125.json
@@ -22,5 +22,6 @@
     "subdomain_title": "Facebook workplace domain",
     "subdomain_ui_help": "Enter your organization's Workplace domain.",
     "subdomain_ui_suffix": ".facebook.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/126.json
+++ b/manifests/definitions/126.json
@@ -12,6 +12,5 @@
   "scope": "https://web.telegram.org",
   "bx_keep_always_loaded": true,
   "bx_legacy_service_id": "telegram",
-  "bx_isolated_session": true,
   "recommendedPosition": "10"
 }

--- a/manifests/definitions/126.json
+++ b/manifests/definitions/126.json
@@ -12,5 +12,6 @@
   "scope": "https://web.telegram.org",
   "bx_keep_always_loaded": true,
   "bx_legacy_service_id": "telegram",
+  "bx_isolated_session": true,
   "recommendedPosition": "10"
 }

--- a/manifests/definitions/131.json
+++ b/manifests/definitions/131.json
@@ -11,6 +11,5 @@
   "theme_color": "#5559AE",
   "scope": "https://teams.live.com",
   "bx_legacy_service_id": "microsoft-teams",
-  "bx_isolated_session": true,
   "recommendedPosition": "25"
 }

--- a/manifests/definitions/131.json
+++ b/manifests/definitions/131.json
@@ -11,5 +11,6 @@
   "theme_color": "#5559AE",
   "scope": "https://teams.live.com",
   "bx_legacy_service_id": "microsoft-teams",
+  "bx_isolated_session": true,
   "recommendedPosition": "25"
 }

--- a/manifests/definitions/132.json
+++ b/manifests/definitions/132.json
@@ -15,5 +15,6 @@
     "presets": [
       "on-premise"
     ]
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/13978.json
+++ b/manifests/definitions/13978.json
@@ -14,5 +14,6 @@
     "presets": [
       "on-premise"
     ]
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/14.json
+++ b/manifests/definitions/14.json
@@ -25,5 +25,6 @@
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://mail.google.com/mail/u/{{userIdentity.profileData.email}}"
   },
+  "bx_use_default_session": true,
   "recommendedPosition": "1"
 }

--- a/manifests/definitions/140.json
+++ b/manifests/definitions/140.json
@@ -11,5 +11,6 @@
   "theme_color": "#0070C9",
   "scope": "https://outlook.live.com",
   "bx_legacy_service_id": "outlook",
+  "bx_isolated_session": true,
   "recommendedPosition": "12"
 }

--- a/manifests/definitions/140.json
+++ b/manifests/definitions/140.json
@@ -11,6 +11,5 @@
   "theme_color": "#0070C9",
   "scope": "https://outlook.live.com",
   "bx_legacy_service_id": "outlook",
-  "bx_isolated_session": true,
   "recommendedPosition": "12"
 }

--- a/manifests/definitions/14076.json
+++ b/manifests/definitions/14076.json
@@ -18,5 +18,6 @@
     "instance_wording": "account",
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://play.google.com/console"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/142.json
+++ b/manifests/definitions/142.json
@@ -15,5 +15,6 @@
     "presets": [
       "on-premise"
     ]
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/14658.json
+++ b/manifests/definitions/14658.json
@@ -9,6 +9,5 @@
     }
   ],
   "theme_color": "#0470C7",
-  "bx_isolated_session": true,
   "scope": "https://outlook.office.com/"
 }

--- a/manifests/definitions/14658.json
+++ b/manifests/definitions/14658.json
@@ -9,5 +9,6 @@
     }
   ],
   "theme_color": "#0470C7",
+  "bx_isolated_session": true,
   "scope": "https://outlook.office.com/"
 }

--- a/manifests/definitions/152.json
+++ b/manifests/definitions/152.json
@@ -15,5 +15,6 @@
     "presets": [
       "on-premise"
     ]
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/156.json
+++ b/manifests/definitions/156.json
@@ -20,5 +20,6 @@
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://keep.google.com/{{#if moreThanOneIdentity}}u/{{userIdentity.profileData.email}}{{/if}}"
   },
+  "bx_use_default_session": true,
   "recommendedPosition": "14"
 }

--- a/manifests/definitions/16.json
+++ b/manifests/definitions/16.json
@@ -25,5 +25,6 @@
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://drive.google.com/drive/{{#if moreThanOneIdentity}}u/{{userIdentity.profileData.email}}{{/if}}",
     "new_page_url_tpl": "https://drive.google.com/drive/{{#if moreThanOneIdentity}}u/{{userIdentity.profileData.email}}{{/if}}"
   },
+  "bx_use_default_session": true,
   "recommendedPosition": "3"
 }

--- a/manifests/definitions/164.json
+++ b/manifests/definitions/164.json
@@ -10,5 +10,6 @@
   ],
   "theme_color": "#00ABF1",
   "scope": "https://tweetdeck.twitter.com",
-  "bx_legacy_service_id": "tweetdeck"
+  "bx_legacy_service_id": "tweetdeck",
+  "bx_isolated_session": true
 }

--- a/manifests/definitions/164.json
+++ b/manifests/definitions/164.json
@@ -10,6 +10,5 @@
   ],
   "theme_color": "#00ABF1",
   "scope": "https://tweetdeck.twitter.com",
-  "bx_legacy_service_id": "tweetdeck",
-  "bx_isolated_session": true
+  "bx_legacy_service_id": "tweetdeck"
 }

--- a/manifests/definitions/18.json
+++ b/manifests/definitions/18.json
@@ -26,5 +26,6 @@
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://calendar.google.com/calendar/{{#if moreThanOneIdentity}}b/{{userIdentity.profileData.email}}{{/if}}"
   },
+  "bx_use_default_session": true,
   "recommendedPosition": "2"
 }

--- a/manifests/definitions/208.json
+++ b/manifests/definitions/208.json
@@ -19,5 +19,6 @@
     "instance_wording": "account",
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://tagmanager.google.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/21.json
+++ b/manifests/definitions/21.json
@@ -29,6 +29,7 @@
     "subdomain_ui_help": "Enter your team's Slack domain.",
     "subdomain_ui_suffix": ".slack.com"
   },
+  "bx_use_default_session": true,
   "main": "slack/main",
   "renderer": "slack/renderer",
   "recommendedPosition": "5"

--- a/manifests/definitions/214.json
+++ b/manifests/definitions/214.json
@@ -19,5 +19,6 @@
     "instance_wording": "account",
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://contacts.google.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/22733.json
+++ b/manifests/definitions/22733.json
@@ -20,5 +20,6 @@
     "subdomain_title": "Canny domain",
     "subdomain_ui_help": "Enter your team's Canny domain.",
     "subdomain_ui_suffix": ".canny.io"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/228.json
+++ b/manifests/definitions/228.json
@@ -19,5 +19,6 @@
     "instance_wording": "account",
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://www.google.com/adsense"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/230.json
+++ b/manifests/definitions/230.json
@@ -21,5 +21,6 @@
     "subdomain_title": "Lucca domain",
     "subdomain_ui_help": "Enter your company Lucca domain.",
     "subdomain_ui_suffix": ".ilucca.net"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/244.json
+++ b/manifests/definitions/244.json
@@ -19,5 +19,6 @@
     "instance_wording": "account",
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://console.cloud.google.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/245.json
+++ b/manifests/definitions/245.json
@@ -19,5 +19,6 @@
     "instance_wording": "account",
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://play.google.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/246.json
+++ b/manifests/definitions/246.json
@@ -19,5 +19,6 @@
     "instance_wording": "account",
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://search.google.com/search-console"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/254.json
+++ b/manifests/definitions/254.json
@@ -11,6 +11,7 @@
   "theme_color": "#C75B12",
   "scope": "https://www.office.com",
   "bx_legacy_service_id": "office-365",
+  "bx_isolated_session": true,
   "extended_scopes": [
     "https://office.live.com",
     "https://www.onenote.com",

--- a/manifests/definitions/254.json
+++ b/manifests/definitions/254.json
@@ -11,7 +11,6 @@
   "theme_color": "#C75B12",
   "scope": "https://www.office.com",
   "bx_legacy_service_id": "office-365",
-  "bx_isolated_session": true,
   "extended_scopes": [
     "https://office.live.com",
     "https://www.onenote.com",

--- a/manifests/definitions/263.json
+++ b/manifests/definitions/263.json
@@ -22,5 +22,6 @@
     "subdomain_title": "Staffomatic domain",
     "subdomain_ui_help": "Enter your team's Staffomatic domain.",
     "subdomain_ui_suffix": ".staffomaticapp.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/27.json
+++ b/manifests/definitions/27.json
@@ -26,5 +26,6 @@
     "subdomain_ui_help": "Enter your team's Slite domain.",
     "subdomain_ui_suffix": ".slite.com"
   },
+  "bx_use_default_session": true,
   "main": "slite/main"
 }

--- a/manifests/definitions/273.json
+++ b/manifests/definitions/273.json
@@ -19,5 +19,6 @@
     "instance_wording": "account",
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://photos.google.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/291.json
+++ b/manifests/definitions/291.json
@@ -25,5 +25,6 @@
     "subdomain_title": "Chargebee domain",
     "subdomain_ui_help": "Enter your team's Chargebee domain.",
     "subdomain_ui_suffix": ".chargebee.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/292.json
+++ b/manifests/definitions/292.json
@@ -15,5 +15,6 @@
     "presets": [
       "on-premise"
     ]
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/299.json
+++ b/manifests/definitions/299.json
@@ -20,5 +20,6 @@
     "instance_wording": "account",
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://meet.google.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/30.json
+++ b/manifests/definitions/30.json
@@ -22,5 +22,6 @@
     "subdomain_title": "Near subdomain",
     "subdomain_ui_help": "Enter your team's Near domain.",
     "subdomain_ui_suffix": ".nearcrm.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/307.json
+++ b/manifests/definitions/307.json
@@ -15,5 +15,6 @@
     "presets": [
       "on-premise"
     ]
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/338.json
+++ b/manifests/definitions/338.json
@@ -21,5 +21,6 @@
     "subdomain_title": "YouTrack domain name",
     "subdomain_ui_help": "Enter your YouTrack domain name.",
     "subdomain_ui_suffix": ".myjetbrains.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/342.json
+++ b/manifests/definitions/342.json
@@ -11,5 +11,6 @@
   "theme_color": "#094AB1",
   "scope": "https://onedrive.live.com",
   "bx_legacy_service_id": "onedrive",
+  "bx_isolated_session": true,
   "recommendedPosition": "29"
 }

--- a/manifests/definitions/342.json
+++ b/manifests/definitions/342.json
@@ -11,6 +11,5 @@
   "theme_color": "#094AB1",
   "scope": "https://onedrive.live.com",
   "bx_legacy_service_id": "onedrive",
-  "bx_isolated_session": true,
   "recommendedPosition": "29"
 }

--- a/manifests/definitions/35.json
+++ b/manifests/definitions/35.json
@@ -19,5 +19,6 @@
     "instance_wording": "account",
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://ads.google.com/aw/overview"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/355.json
+++ b/manifests/definitions/355.json
@@ -24,5 +24,6 @@
     "subdomain_title": "HipChat domain",
     "subdomain_ui_help": "Enter your team's HipChat domain.",
     "subdomain_ui_suffix": ".hipchat.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/367.json
+++ b/manifests/definitions/367.json
@@ -19,5 +19,6 @@
     "instance_wording": "account",
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://www.google.com/ddm/bidmanager"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/370.json
+++ b/manifests/definitions/370.json
@@ -22,5 +22,6 @@
     "subdomain_title": "Kanban Tool company account",
     "subdomain_ui_help": "Enter your Kanban Tool company account.",
     "subdomain_ui_suffix": ".kanbantool.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/371.json
+++ b/manifests/definitions/371.json
@@ -21,5 +21,6 @@
     "subdomain_title": "Freshbooks domain",
     "subdomain_ui_help": "Enter your business Freshbooks domain.",
     "subdomain_ui_suffix": ".freshbooks.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/374.json
+++ b/manifests/definitions/374.json
@@ -22,5 +22,6 @@
     "subdomain_title": "Freshteam domain",
     "subdomain_ui_help": "Enter your team's Freshteam domain.",
     "subdomain_ui_suffix": ".freshteam.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/375.json
+++ b/manifests/definitions/375.json
@@ -22,5 +22,6 @@
     "subdomain_title": "Freshsales domain",
     "subdomain_ui_help": "Enter your team's Freshsales domain.",
     "subdomain_ui_suffix": ".freshsales.io"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/376.json
+++ b/manifests/definitions/376.json
@@ -22,5 +22,6 @@
     "subdomain_title": "Freshcaller domain",
     "subdomain_ui_help": "Enter your team's Freshcaller domain.",
     "subdomain_ui_suffix": ".freshcaller.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/380.json
+++ b/manifests/definitions/380.json
@@ -19,5 +19,6 @@
     "instance_wording": "account",
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://console.firebase.google.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/383.json
+++ b/manifests/definitions/383.json
@@ -23,5 +23,6 @@
     "subdomain_title": "freshdesk domain",
     "subdomain_ui_help": "Enter your team's freshdesk domain.",
     "subdomain_ui_suffix": ".freshdesk.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/385.json
+++ b/manifests/definitions/385.json
@@ -22,5 +22,6 @@
     "subdomain_title": "Monday domain",
     "subdomain_ui_help": "Enter your team's Monday domain.",
     "subdomain_ui_suffix": ".monday.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/39.json
+++ b/manifests/definitions/39.json
@@ -16,5 +16,6 @@
       "on-premise"
     ]
   },
+  "bx_use_default_session": true,
   "recommendedPosition": "19"
 }

--- a/manifests/definitions/399.json
+++ b/manifests/definitions/399.json
@@ -28,5 +28,6 @@
     "subdomain_title": "Gorgias domain",
     "subdomain_ui_help": "Enter your team's Gorgias domain.",
     "subdomain_ui_suffix": ".gorgias.io"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/41.json
+++ b/manifests/definitions/41.json
@@ -19,5 +19,6 @@
     "instance_wording": "account",
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://analytics.google.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/416.json
+++ b/manifests/definitions/416.json
@@ -22,5 +22,6 @@
     "instance_wording": "account",
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://lookerstudio.google.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/44.json
+++ b/manifests/definitions/44.json
@@ -21,5 +21,6 @@
     "subdomain_title": "Quandora domain",
     "subdomain_ui_help": "Enter your team's Quandora domain.",
     "subdomain_ui_suffix": ".quandora.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/479.json
+++ b/manifests/definitions/479.json
@@ -25,5 +25,6 @@
     "subdomain_title": "Teachbase domain",
     "subdomain_ui_help": "Enter your team's Teachbase domain.",
     "subdomain_ui_suffix": ".teachbase.ru"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/483.json
+++ b/manifests/definitions/483.json
@@ -25,5 +25,6 @@
     "subdomain_title": "Databricks domain",
     "subdomain_ui_help": "Enter your team's Databricks domain.",
     "subdomain_ui_suffix": ".databricks.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/489.json
+++ b/manifests/definitions/489.json
@@ -25,5 +25,6 @@
     "subdomain_title": "FareHarbor domain",
     "subdomain_ui_help": "Enter your team's FareHarbor domain.",
     "subdomain_ui_suffix": ".fareharbor.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/503.json
+++ b/manifests/definitions/503.json
@@ -28,5 +28,6 @@
     "subdomain_title": "CapsuleCRM domain",
     "subdomain_ui_help": "Enter your team's CapsuleCRM domain.",
     "subdomain_ui_suffix": ".capsulecrm.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/505.json
+++ b/manifests/definitions/505.json
@@ -27,5 +27,6 @@
     "subdomain_title": "Flexie domain",
     "subdomain_ui_help": "Enter your team's Flexie domain.",
     "subdomain_ui_suffix": ".flexie.io"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/507.json
+++ b/manifests/definitions/507.json
@@ -27,5 +27,6 @@
     "subdomain_title": "Kayako domain",
     "subdomain_ui_help": "Enter your team's Kayako domain.",
     "subdomain_ui_suffix": ".kayako.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/517.json
+++ b/manifests/definitions/517.json
@@ -26,5 +26,6 @@
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://chat.google.com/chat/u/{{userIdentity.profileData.email}}"
   },
+  "bx_use_default_session": true,
   "recommendedPosition": "24"
 }

--- a/manifests/definitions/539.json
+++ b/manifests/definitions/539.json
@@ -23,5 +23,6 @@
     "presets": [
       "on-premise"
     ]
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/541.json
+++ b/manifests/definitions/541.json
@@ -28,5 +28,6 @@
     "subdomain_title": "Procurify domain",
     "subdomain_ui_help": "Enter your company's Propcurify domain.",
     "subdomain_ui_suffix": ".procurify.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/542.json
+++ b/manifests/definitions/542.json
@@ -29,5 +29,6 @@
     "subdomain_title": "Freshservice domain",
     "subdomain_ui_help": "Enter your organization's Freshservice domain.",
     "subdomain_ui_suffix": ".freshservice.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/553.json
+++ b/manifests/definitions/553.json
@@ -28,5 +28,6 @@
     "subdomain_title": "Ryver domain",
     "subdomain_ui_help": "Enter your organization's Ryver domain.",
     "subdomain_ui_suffix": ".ryver.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/557.json
+++ b/manifests/definitions/557.json
@@ -29,5 +29,6 @@
     "subdomain_title": "Rocket.Chat domain",
     "subdomain_ui_help": "Enter your organization's Rocket.Chat domain.",
     "subdomain_ui_suffix": ".rocket.chat"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/564.json
+++ b/manifests/definitions/564.json
@@ -22,5 +22,6 @@
     "instance_wording": "account",
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://classroom.google.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/566.json
+++ b/manifests/definitions/566.json
@@ -28,5 +28,6 @@
     "subdomain_title": "Agile CRM domain",
     "subdomain_ui_help": "Enter your organization's Agile CRM domain.",
     "subdomain_ui_suffix": ".agilecrm.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/574.json
+++ b/manifests/definitions/574.json
@@ -23,5 +23,6 @@
     "instance_wording": "account",
     "instance_label_tpl": "{{email}}",
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://voice.google.com/u/0/calls"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/580.json
+++ b/manifests/definitions/580.json
@@ -22,5 +22,6 @@
     "presets": [
       "on-premise"
     ]
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/59.json
+++ b/manifests/definitions/59.json
@@ -11,6 +11,5 @@
   "theme_color": "#1DA1F2",
   "scope": "https://twitter.com",
   "bx_legacy_service_id": "twitter",
-  "bx_isolated_session": true,
   "recommendedPosition": "9"
 }

--- a/manifests/definitions/59.json
+++ b/manifests/definitions/59.json
@@ -1,7 +1,7 @@
 {
   "name": "Twitter",
   "category": "Social Media & Advertising",
-  "start_url": "https://twitter.com/",
+  "start_url": "https://twitter.com/i/flow/login",
   "icons": [
     {
       "src": "https://cdn.filestackcontent.com/d8JTzPSSvS3cVL6yO62A",
@@ -11,5 +11,6 @@
   "theme_color": "#1DA1F2",
   "scope": "https://twitter.com",
   "bx_legacy_service_id": "twitter",
+  "bx_isolated_session": true,
   "recommendedPosition": "9"
 }

--- a/manifests/definitions/595.json
+++ b/manifests/definitions/595.json
@@ -29,5 +29,6 @@
     "subdomain_title": "Space ID",
     "subdomain_ui_help": "Enter your Space ID.",
     "subdomain_ui_suffix": ".backlog.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/601.json
+++ b/manifests/definitions/601.json
@@ -27,5 +27,6 @@
     "subdomain_title": "Freebe.me domain",
     "subdomain_ui_help": "Enter your Freebe.me domain",
     "subdomain_ui_suffix": ".freebe.me"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/602.json
+++ b/manifests/definitions/602.json
@@ -27,5 +27,6 @@
     "subdomain_title": "Zenvest domain",
     "subdomain_ui_help": "Enter your Zenvest domain",
     "subdomain_ui_suffix": ".zenvest.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/62.json
+++ b/manifests/definitions/62.json
@@ -25,5 +25,6 @@
     "subdomain_title": "Zendesk domain",
     "subdomain_ui_help": "Enter your company's Zendesk subdomain.",
     "subdomain_ui_suffix": ".zendesk.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/6286.json
+++ b/manifests/definitions/6286.json
@@ -18,5 +18,6 @@
     "presets": [
       "on-premise"
     ]
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/666.json
+++ b/manifests/definitions/666.json
@@ -24,5 +24,6 @@
     "subdomain_title": "Odoo domain",
     "subdomain_ui_help": "Enter your Odoo domain",
     "subdomain_ui_suffix": ".odoo.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/676.json
+++ b/manifests/definitions/676.json
@@ -24,5 +24,6 @@
     "subdomain_title": "Jandi domain",
     "subdomain_ui_help": "Enter your Jandi domain",
     "subdomain_ui_suffix": ".jandi.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/677.json
+++ b/manifests/definitions/677.json
@@ -24,5 +24,6 @@
     "subdomain_title": "GrooveHQ domain",
     "subdomain_ui_help": "Enter your GrooveHQ domain",
     "subdomain_ui_suffix": ".groovehq.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/681.json
+++ b/manifests/definitions/681.json
@@ -24,5 +24,6 @@
     "subdomain_title": "Hygger domain",
     "subdomain_ui_help": "Enter your Hygger domain",
     "subdomain_ui_suffix": ".hygger.io"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/682.json
+++ b/manifests/definitions/682.json
@@ -25,5 +25,6 @@
     "subdomain_title": "Zulip domain",
     "subdomain_ui_help": "Enter your Zulip domain",
     "subdomain_ui_suffix": ".zulipchat.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/684.json
+++ b/manifests/definitions/684.json
@@ -24,5 +24,6 @@
     "subdomain_title": "Planfix domain",
     "subdomain_ui_help": "Enter your Planfix domain",
     "subdomain_ui_suffix": ".planfix.ru"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/686.json
+++ b/manifests/definitions/686.json
@@ -24,5 +24,6 @@
     "subdomain_title": "PagerDuty domain",
     "subdomain_ui_help": "Enter your PagerDuty domain",
     "subdomain_ui_suffix": ".pagerduty.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/687.json
+++ b/manifests/definitions/687.json
@@ -24,5 +24,6 @@
     "subdomain_title": "Kanbanize domain",
     "subdomain_ui_help": "Enter your Kanbanize domain",
     "subdomain_ui_suffix": ".kanbanize.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/78.json
+++ b/manifests/definitions/78.json
@@ -15,5 +15,6 @@
     "presets": [
       "on-premise"
     ]
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/manifests/definitions/86.json
+++ b/manifests/definitions/86.json
@@ -22,5 +22,6 @@
     "subdomain_title": "Domo domain",
     "subdomain_ui_help": "Enter your organization's Domo domain.",
     "subdomain_ui_suffix": ".domo.com"
-  }
+  },
+  "bx_use_default_session": true
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "station-desktop-app",
   "private": true,
   "productName": "Station",
-  "version": "2.7.0-b1",
+  "version": "2.7.0-b2",
   "description": "Station",
   "homepage": "https://getstation.com",
   "author": {


### PR DESCRIPTION
The motivation for the PR are the issues #287 #259. We have the same problem with other apps (Facebook, Twitter and so on)
So I've changed the default behaviour and now all applications use their own session instead of sharing default. It uses [this](https://www.electronjs.org/docs/latest/api/webview-tag#partition) feature of `<webview>` object.
I've also added new parameter to the application manifest `bx_use_default_session`. It forces app to use shared session as before.
I've disabled isolated session for all apps which have multi instance support. It doesn't work out of the box and I don't have time now to find the cause of the issue. It can be done later.

* Fixes #131 
* Fixed #259
* Fixed #275 
* Fixed #287
* Fixed #302 
* 
