### PR TITLE
Fix User-Agent header problem for Google Chat. 

### DIFF
--- a/app/session.ts
+++ b/app/session.ts
@@ -1,6 +1,13 @@
 import { Session, OnBeforeSendHeadersListenerDetails, BeforeSendResponse } from 'electron';
 import enhanceWebRequest from 'electron-better-web-request';
 
+/*
+These applications are sensitive to the User-Agent header and have to be rechecked in case of changing the default value:
+- Google Meet (299.json)
+- Google Chat (517.json)
+
+it's better to remove bx_override_user_agent attribute from manifest before the check to be sure that it's still necessary.
+*/
 const defaultUserAgent = 'Chrome/114.0.5735.289';
 
 const getUserAgentForApp = (url: string, currentUserAgent: string): string => {

--- a/appstore/src/static/app-removed.html
+++ b/appstore/src/static/app-removed.html
@@ -1,0 +1,11 @@
+<html>
+    <body>
+        <br>
+        <br>
+        <br>
+        <center>
+            <h2>The application has been removed from the store.</h2>
+            <h3>Please use it's replacement instead.</h3>
+        </center>
+    </body>
+</html>

--- a/manifests/definitions/115.json
+++ b/manifests/definitions/115.json
@@ -1,15 +1,14 @@
 {
   "name": "Hangouts",
   "category": "Communication & Collaboration",
-  "start_url": "https://hangouts.google.com/",
-  "icons": [
-    {
-      "src": "https://cdn.filestackcontent.com/jYO38GpXTlWHrZ36Cd0M",
-      "platform": "browserx"
-    }
-  ],
   "theme_color": "#82B750",
-  "scope": "https://hangouts.google.com",
+
+
+  "start_url": "station://appstore/static/app-removed.html",
+  "doNotList": true,
+  "bx_use_default_session": true,
+
+  
   "bx_keep_always_loaded": true,
   "bx_single_page": true,
   "bx_legacy_service_id": "google-hangouts",

--- a/manifests/definitions/517.json
+++ b/manifests/definitions/517.json
@@ -27,5 +27,6 @@
     "start_url_tpl": "https://accounts.google.com/AddSession?passive=true&Email={{userIdentity.profileData.email}}&continue=https://chat.google.com/chat/u/{{userIdentity.profileData.email}}"
   },
   "bx_use_default_session": true,
+  "bx_override_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.5735.289 Safari/537.36",
   "recommendedPosition": "24"
 }


### PR DESCRIPTION

- Fixed **I cannot log in to Google Chat (Workspace)** #319 
- Hangouts is removed from store as it was replaced by Google Chat
_We can't just delete manifest because it crashes the Station if app was added before._