### PR TITLE
Fix application icon in Linux

### DIFF
--- a/app/utils/resources.ts
+++ b/app/utils/resources.ts
@@ -1,13 +1,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-export const getResourcePath = (rootPath: string) => path.resolve(__dirname, '../..', rootPath);
+const getResourcePath = (rootPath: string) => path.resolve(__dirname, '../..', rootPath);
 
 /**
  * Returns the full path of the PNG icon of the app
  */
 export const getResourceIconPath = () => {
-  const stableIconPath = getResourcePath('build/icon_512x512.png');
+  const stableIconPath = getResourcePath('resources/icon.png');
   if (fs.existsSync(stableIconPath)) return stableIconPath;
 
   return undefined;

--- a/app/utils/resources.ts
+++ b/app/utils/resources.ts
@@ -1,14 +1,17 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-const getResourcePath = (rootPath: string) => path.resolve(__dirname, '../..', rootPath);
+import { isLinux } from './process';
 
 /**
  * Returns the full path of the PNG icon of the app
  */
 export const getResourceIconPath = () => {
-  const stableIconPath = getResourcePath('resources/icon.png');
-  if (fs.existsSync(stableIconPath)) return stableIconPath;
-
+  if (isLinux) {
+    const stableIconPath = path.resolve(__dirname, '../../resources/icon.png');
+    if (fs.existsSync(stableIconPath)) {
+      return stableIconPath;
+    }
+  }
   return undefined;
 };

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -58,11 +58,11 @@ linux:
   artifactName: ${productName}-${arch}.${ext}
 
 extraResources:
-  - '.env.example'
   - '.env.production'
+  - from: 'build/icon_512x512.png'
+    to: 'icon.png'
 
 files:
-  - 'build/icon_512x512.png'
   - '!**/*.map'
   - from: 'app/static/icon--provider'
     to: 'static/icon--provider'


### PR DESCRIPTION
The application icon is broken in Linux.

![image](https://github.com/getstation/desktop-app/assets/8362098/ffb91a7c-6566-4933-b7f2-46232da0d598)

For MacOS and Windows icon file is used.