### PR TITLE
Download hack for Slack

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "station-desktop-app",
   "private": true,
   "productName": "Station",
-  "version": "2.7.0-b2",
+  "version": "2.8.0-b1",
   "description": "Station",
   "homepage": "https://getstation.com",
   "author": {


### PR DESCRIPTION
Downloading in Slack.com is implemented through opening a new window.
It is mentioned here #331 

So I created the hack based on previous code to cover this case.