### PR TITLE
Do not show "Delete also user data..." dialog on update

### DIFF
--- a/packages/app/build/installer.nsh
+++ b/packages/app/build/installer.nsh
@@ -1,9 +1,15 @@
 !macro customUnInstall
 
-MessageBox MB_YESNO|MB_ICONQUESTION|MB_DEFBUTTON2 "Delete also user data and settings for Station?" IDNO skip
-RMDir /r "$APPDATA\Station"
-RMDir /r "$APPDATA\Stationv2"
+  ${GetParameters} $R0
+  ${GetOptions} $R0 "--update" $R1
+  ${If} ${Errors}
 
-skip:
+    MessageBox MB_YESNO|MB_ICONQUESTION|MB_DEFBUTTON2 "Delete also user data and settings for Station?" IDNO skip
+    RMDir /r "$APPDATA\Station"
+    RMDir /r "$APPDATA\Stationv2"
+
+    skip:
+
+	${endif}
 
 !macroend


### PR DESCRIPTION
### What is this PR

Small fix to eliminate appearing delete user data dialog during update on  Windows.
We should only show this dialog when the user is about to uninstall Station.