### PR TITLE
Rename bx to bxApi

### DIFF
--- a/packages/app/src/applications/multi-instance-configuration/webui/MultiInstanceConfigurator.tsx
+++ b/packages/app/src/applications/multi-instance-configuration/webui/MultiInstanceConfigurator.tsx
@@ -10,7 +10,7 @@ import { MultiInstanceConfigPreset as Preset } from '../../manifest-provider/typ
 import NormalFlowForm from './components/NormalFlowForm';
 import { getPresets } from '../../manifest-provider/helpers';
 
-const requestGoogleSignin = () => window.bx.identities.requestLogin('google');
+const requestGoogleSignin = () => window.bxApi.identities.requestLogin('google');
 
 const {
   Undefined: UndefinedPreset,
@@ -79,28 +79,28 @@ export default class MultiInstanceConfigurator extends React.Component<Props, St
   }
 
   submitSubdomainForm = (subdomain: string) => {
-    window.bx.applications.setConfigData(this.props.applicationId, { subdomain });
+    window.bxApi.applications.setConfigData(this.props.applicationId, { subdomain });
   }
 
   submitIdentityForm = (identityId: string) => {
-    window.bx.applications.setConfigData(this.props.applicationId, { identityId });
+    window.bxApi.applications.setConfigData(this.props.applicationId, { identityId });
   }
 
   submitOnPremiseForm = (customURL: string) => {
-    window.bx.applications.setConfigData(this.props.applicationId, { customURL });
+    window.bxApi.applications.setConfigData(this.props.applicationId, { customURL });
   }
 
   submitNormalForm = () => {
-    window.bx.applications.setConfigData(this.props.applicationId, {});
+    window.bxApi.applications.setConfigData(this.props.applicationId, {});
   }
 
   removeApplication = () => {
-    window.bx.applications.uninstall(this.props.applicationId);
+    window.bxApi.applications.uninstall(this.props.applicationId);
   }
 
   componentDidMount() {
     const { manifestURL } = this.props;
-    window.bx.manifest.getManifest(manifestURL).then(({ body }) => {
+    window.bxApi.manifest.getManifest(manifestURL).then(({ body }) => {
       const manifest = body;
       const presets = this.getPresets(manifest);
       const selectedPreset = isOnlyOnPremise(presets) ? UndefinedPreset : presets[0];

--- a/packages/app/src/applications/multi-instance-configuration/webui/components/ChooseIdentityForm.tsx
+++ b/packages/app/src/applications/multi-instance-configuration/webui/components/ChooseIdentityForm.tsx
@@ -51,11 +51,11 @@ export default class ChooseIdentityForm extends React.PureComponent<Props, State
   }
 
   UNSAFE_componentWillMount() {
-    window.bx.identities.addIdentitiesChangeListener(this.onIdentitiesChanged);
+    window.bxApi.identities.addIdentitiesChangeListener(this.onIdentitiesChanged);
   }
 
   componentWillUnmount() {
-    window.bx.identities.removeIdentitiesChangeListener(this.onIdentitiesChanged);
+    window.bxApi.identities.removeIdentitiesChangeListener(this.onIdentitiesChanged);
   }
 
   render() {

--- a/packages/app/src/applications/multi-instance-configuration/webui/index.tsx
+++ b/packages/app/src/applications/multi-instance-configuration/webui/index.tsx
@@ -14,7 +14,7 @@ const manifestURL = params.get('manifestURL')!;
 const applicationId = params.get('applicationId')!;
 
 const themeColorsObservable = new Subject<any>();
-window.bx.theme.addThemeColorsChangeListener(
+window.bxApi.theme.addThemeColorsChangeListener(
   (_: any, result: any) => themeColorsObservable.next(result)
 );
 

--- a/packages/app/src/notification-center/webview-preload.ts
+++ b/packages/app/src/notification-center/webview-preload.ts
@@ -66,7 +66,7 @@ export class BxNotification extends EventTarget('click', 'error', 'close', 'show
     });
 
     this._registerIPC();
-    window.bx.notificationCenter.sendNotification(this.id, {
+    window.bxApi.notificationCenter.sendNotification(this.id, {
       timestamp: this.timestamp,
       title: this.title,
       body: this.body,
@@ -87,17 +87,17 @@ export class BxNotification extends EventTarget('click', 'error', 'close', 'show
   }
 
   close() {
-    window.bx.notificationCenter.closeNotification(this.id);
+    window.bxApi.notificationCenter.closeNotification(this.id);
     // ipcRenderer.send('notification-close', this.id);
   }
 
   _registerIPC() {
-    window.bx.notificationCenter.addNotificationClickListener(this._handleNotificationClickIPC);
+    window.bxApi.notificationCenter.addNotificationClickListener(this._handleNotificationClickIPC);
     // ipcRenderer.on('trigger-notification-click', this._handleNotificationClickIPC);
   }
 
   _unregisterIPC() {
-    window.bx.notificationCenter.removeNotificationClickListener(this._handleNotificationClickIPC);
+    window.bxApi.notificationCenter.removeNotificationClickListener(this._handleNotificationClickIPC);
     // ipcRenderer.removeListener('trigger-notification-click', this._handleNotificationClickIPC);
   }
 

--- a/packages/app/src/plugins/bxapi.d.ts
+++ b/packages/app/src/plugins/bxapi.d.ts
@@ -174,6 +174,6 @@ interface Bx {
 
 declare global {
   interface Window { 
-    bx: Bx;
+    bxApi: Bx;
   }
 }

--- a/packages/app/src/plugins/injected-js/messengerInjectedScript.js
+++ b/packages/app/src/plugins/injected-js/messengerInjectedScript.js
@@ -64,7 +64,7 @@ const turnOffAudioVolumeObserver = target => {
 
 let disconnectTurnOffAudioVolumeObserver;
 
-window.bx.notificationCenter.addSnoozeDurationInMsChangeListener((_, duration) => {
+window.bxApi.notificationCenter.addSnoozeDurationInMsChangeListener((_, duration) => {
   if (duration && !document.location.pathname.includes('/videocall/incall/')) {
     disconnectTurnOffAudioVolumeObserver = turnOffAudioVolumeObserver(document.body);
   } else {

--- a/packages/app/src/plugins/injected-js/whatsappInjectedScript.js
+++ b/packages/app/src/plugins/injected-js/whatsappInjectedScript.js
@@ -13,6 +13,6 @@ Audio.prototype.play = function() {
   return Promise.resolve();
 };
 
-window.bx.notificationCenter.addSnoozeDurationInMsChangeListener((_, duration) => {
+window.bxApi.notificationCenter.addSnoozeDurationInMsChangeListener((_, duration) => {
   snoozed = Boolean(duration);
 });

--- a/packages/app/src/plugins/webview-preload.js
+++ b/packages/app/src/plugins/webview-preload.js
@@ -122,6 +122,6 @@
      }
     };
 
-    contextBridge.exposeInMainWorld('bx', bxApi);
+    contextBridge.exposeInMainWorld('bxApi', bxApi);
 
     console.log('>>>> contextBridge done')

--- a/packages/app/src/static/preload/preload.js
+++ b/packages/app/src/static/preload/preload.js
@@ -245,7 +245,7 @@ const postload = Object.keys(window);
 
 // List of allowed exposure on globals
 export const whitelist = new Set([
-  'bx',
+  'bxApi',
   'chrome',
   '_docs_chrome_extension_exists',
   '_docs_chrome_extension_features_version',

--- a/packages/appstore/src/HOC/withCustomApplications.tsx
+++ b/packages/appstore/src/HOC/withCustomApplications.tsx
@@ -14,7 +14,7 @@ export default function withCustomApplications(Component: React.Component<any>) 
     });
 
     React.useEffect(() => {
-      window.bx.applications.getPrivateApps().then(({ body }) => {
+      window.bxApi.applications.getPrivateApps().then(({ body }) => {
         setData({
           privateApps: body.map(app => {
             return {

--- a/packages/appstore/src/api.ts
+++ b/packages/appstore/src/api.ts
@@ -1,7 +1,7 @@
 export const findApplicationByName = (applicationName: string) => {
 
-  if ('bx' in window) {
-    const bxApi = window.bx;
+  if ('bxApi' in window) {
+    const bxApi = window.bxApi;
 
     return bxApi.applications.search(applicationName).then(({ body }) => {
       return body || [];

--- a/packages/appstore/src/app-request/sagas.ts
+++ b/packages/appstore/src/app-request/sagas.ts
@@ -24,7 +24,7 @@ function* handleAppRequest(request: SubmitAppRequestAction): SagaIterator {
     };
 
     try {
-      const { body } = yield call(window.bx.applications.requestPrivate, applicationRecipe);
+      const { body } = yield call(window.bxApi.applications.requestPrivate, applicationRecipe);
       yield put(setApiResponse(ApiResponse.Done));
       yield put(setApplicationCreated({ id: body.id, bxAppManifestURL: body.bxAppManifestURL }));
     } catch (e) {

--- a/packages/appstore/src/app.tsx
+++ b/packages/appstore/src/app.tsx
@@ -58,9 +58,9 @@ class AppImpl extends React.Component<Props, IState> {
 
   // tslint:disable-next-line function-name
   async UNSAFE_componentWillMount() {
-    if ('bx' in window) {
+    if ('bxApi' in window) {
       // @ts-ignore : bx attached to window
-      const bxApi = window.bx;
+      const bxApi = window.bxApi;
 
       bxApi.theme.addThemeColorsChangeListener((_: any, themeColors: string[]) => {
         this.setState({ themeColors })

--- a/packages/appstore/src/components/AppStoreContent/AppStoreMyCustomApps/AppStoreMyCustomApps.tsx
+++ b/packages/appstore/src/components/AppStoreContent/AppStoreMyCustomApps/AppStoreMyCustomApps.tsx
@@ -113,7 +113,7 @@ class AppStoreMyCustomApps extends React.PureComponent<Props, AppStoreMyCustomAp
   }
 
   deleteApplication = (app: Application) => {
-    window.bx.applications.uninstallByManifest(app.bxAppManifestURL).then(() => {
+    window.bxApi.applications.uninstallByManifest(app.bxAppManifestURL).then(() => {
       this.exitFlow(false);
       location.reload();
     }).catch((e) => {


### PR DESCRIPTION
### What is this PR

`window.bx` is changed to `window.bxApi`
Name `bx` is too short and similar to transpiled code. It interferes with existing code in some apps and causes errors.
Examples of such apps are Google Cloud Console and Firebase Console.
