### PR TITLE
feat(context-menu): add "Copy Image to Clipboard" functionality to image context menu

### DIFF
--- a/packages/app/src/context-menu.ts
+++ b/packages/app/src/context-menu.ts
@@ -117,17 +117,9 @@ export default class ContextMenu extends EventEmitter {
           id: 'copyImage',
           label: 'Copy Image to Clipboard',
           click() {
-            // Fetch the image and copy to clipboard
-            fetch(props.srcURL)
-              .then(response => response.arrayBuffer())
-              .then(buffer => {
-                const { nativeImage } = require('electron');
-                const image = nativeImage.createFromBuffer(Buffer.from(buffer));
-                clipboard.writeImage(image);
-              })
-              .catch(error => {
-                console.error('Failed to copy image to clipboard:', error);
-              });
+            if (webContents) {
+              webContents.copyImageAt(props.x, props.y);
+            }
           },
         },
         {

--- a/packages/app/src/context-menu.ts
+++ b/packages/app/src/context-menu.ts
@@ -114,6 +114,23 @@ export default class ContextMenu extends EventEmitter {
           },
         },
         {
+          id: 'copyImage',
+          label: 'Copy Image to Clipboard',
+          click() {
+            // Fetch the image and copy to clipboard
+            fetch(props.srcURL)
+              .then(response => response.arrayBuffer())
+              .then(buffer => {
+                const { nativeImage } = require('electron');
+                const image = nativeImage.createFromBuffer(Buffer.from(buffer));
+                clipboard.writeImage(image);
+              })
+              .catch(error => {
+                console.error('Failed to copy image to clipboard:', error);
+              });
+          },
+        },
+        {
           id: 'copyImageUrl',
           label: 'Copy Image URL',
           click() {


### PR DESCRIPTION
## What is this PR

This PR adds a new "Copy Image to Clipboard" feature to the context menu for images in our Electron app. This enhancement complements the existing functionality that allows users to save images or copy image URLs by providing a more direct way to capture image content for pasting elsewhere.

The feature was requested as an enhancement to improve user workflow when working with images, particularly for users who need to quickly transfer image content between applications without saving files to disk first.

Fixes: https://github.com/getstation/desktop-app/issues/200

## How does it work

The implementation uses Electron's native APIs to fetch and process images:

1. Added a new menu item between "Save Image" and "Copy Image URL" options in the image context menu
2. When selected, the feature:
   - Uses `fetch()` to retrieve the image data from the source URL
   - Converts the response to an array buffer
   - Creates a native image object using Electron's `nativeImage.createFromBuffer()`
   - Writes the image to the system clipboard using `clipboard.writeImage()`
   - Includes error handling to gracefully handle failed image fetching attempts

This approach ensures compatibility with various image types and sources while maintaining the existing menu structure and user experience.

## Test instructions

1. **Setup**:
   - Run the Electron application in development mode
   - Navigate to a page that contains images

2. **Testing the feature**:
   - Right-click on any image to open the context menu
   - Verify the "Copy Image to Clipboard" option appears between "Save Image" and "Copy Image URL"
   - Click on the "Copy Image to Clipboard" option

3. **Verifying functionality**:
   - Open any application that accepts image pastes (e.g., Paint, Photoshop, Google Docs)
   - Use Ctrl+V (or Cmd+V on Mac) to paste
   - Confirm that the image from the application is correctly pasted

4. **Regression testing**:
   - Verify the existing "Save Image" and "Copy Image URL" options still work correctly
   - Confirm the overall context menu behavior remains consistent

